### PR TITLE
Rely on new-style permission name to guard loan-types settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.12.0 (IN PROGRESS)
 
 * Support permission for loan-type maintenance. Fixes UIIT-38.
+* Rely on new-style permission name to guard material-types settings.Fixes UIIT-39.
 
 ## [1.11.0](https://github.com/folio-org/ui-items/tree/v1.11.0) (2017-09-01)
 [Full Changelog](https://github.com/folio-org/ui-items/compare/v1.10.1...v1.11.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Support permission for loan-type maintenance. Fixes UIIT-38.
 * Rely on new-style permission name to guard material-types settings.Fixes UIIT-39.
+* Use `<ControlledVocab>` from stripes-smart-components instead of `<AuthorityList>` from stripes-components. See STSMACOM-6. Requires util-notes v0.3.0. Fixes UIIT-74.
 
 ## [1.11.0](https://github.com/folio-org/ui-items/tree/v1.11.0) (2017-09-01)
 [Full Changelog](https://github.com/folio-org/ui-items/compare/v1.10.1...v1.11.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-items
 
+## 1.12.0 (IN PROGRESS)
+
+* Support permission for loan-type maintenance. Fixes UIIT-38.
+
 ## [1.11.0](https://github.com/folio-org/ui-items/tree/v1.11.0) (2017-09-01)
 [Full Changelog](https://github.com/folio-org/ui-items/compare/v1.10.1...v1.11.0)
 
@@ -14,7 +18,7 @@
 ## [1.10.0](https://github.com/folio-org/ui-items/tree/v1.10.0) (2017-08-30)
 [Full Changelog](https://github.com/folio-org/ui-items/compare/v1.9.0...v1.10.0)
 
-* Make settings.material-types.all and settings.loan-types.all visible. For UIIT-38 and -39.
+* Make settings.material-types.all and settings.loan-types.all visible. For UIIT-38 and UIIT-39.
 * Add test suites, carried over from ui-testing. FOLIO-800.
 
 ## [1.9.0](https://github.com/folio-org/ui-items/tree/v1.9.0) (2017-08-23)

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
   "dependencies": {
     "@folio/stripes-components": "^1.8.0",
     "@folio/stripes-form": "^0.8.0",
+    "@folio/util-notes": "^0.3.0",
     "lodash": "^4.17.4",
     "prop-types": "^15.5.10",
     "query-string": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "webpack": "1.11.0"
   },
   "dependencies": {
-    "@folio/stripes-components": "^1.7.0",
+    "@folio/stripes-components": "^1.8.0",
     "@folio/stripes-form": "^0.8.0",
     "lodash": "^4.17.4",
     "prop-types": "^15.5.10",

--- a/settings/LoanTypesSettings.js
+++ b/settings/LoanTypesSettings.js
@@ -1,5 +1,5 @@
 import React, { PropTypes } from 'react';
-import AuthorityList from '@folio/stripes-components/lib/AuthorityList';
+import ControlledVocab from '@folio/util-notes/lib/ControlledVocab';
 
 class LoanTypesSettings extends React.Component {
   static propTypes = {
@@ -10,12 +10,12 @@ class LoanTypesSettings extends React.Component {
 
   constructor(props) {
     super(props);
-    this.connectedAuthorityList = props.stripes.connect(AuthorityList);
+    this.connectedControlledVocab = props.stripes.connect(ControlledVocab);
   }
 
   render() {
     return (
-      <this.connectedAuthorityList
+      <this.connectedControlledVocab
         {...this.props}
         baseUrl="loan-types"
         records="loantypes"

--- a/settings/MaterialTypesSettings.js
+++ b/settings/MaterialTypesSettings.js
@@ -1,5 +1,5 @@
 import React, { PropTypes } from 'react';
-import AuthorityList from '@folio/stripes-components/lib/AuthorityList';
+import ControlledVocab from '@folio/util-notes/lib/ControlledVocab';
 
 class MaterialTypesSettings extends React.Component {
   static propTypes = {
@@ -10,12 +10,12 @@ class MaterialTypesSettings extends React.Component {
 
   constructor(props) {
     super(props);
-    this.connectedAuthorityList = props.stripes.connect(AuthorityList);
+    this.connectedControlledVocab = props.stripes.connect(ControlledVocab);
   }
 
   render() {
     return (
-      <this.connectedAuthorityList
+      <this.connectedControlledVocab
         {...this.props}
         baseUrl="material-types"
         records="mtypes"

--- a/settings/index.js
+++ b/settings/index.js
@@ -16,7 +16,7 @@ const pages = [
     route: 'mtypes',
     label: 'Material types',
     component: MaterialTypesSettings,
-    perm: 'settings.material-types.all',
+    perm: 'ui-items.settings.material-types',
   },
 ];
 

--- a/settings/index.js
+++ b/settings/index.js
@@ -10,7 +10,7 @@ const pages = [
     route: 'loantypes',
     label: 'Loan types',
     component: LoanTypesSettings,
-    perm: 'settings.loan-types.all',
+    perm: 'ui-items.settings.loan-types',
   },
   {
     route: 'mtypes',


### PR DESCRIPTION
Should fix UIIT-38.