### PR TITLE
removing an unused dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,6 @@
     "prop-types": "^15.5.10",
     "query-string": "^5.0.0",
     "react": "^15.4.2",
-    "react-bootstrap": "^0.31.1",
     "react-flexbox-grid": "^1.1.3",
     "react-router-dom": "^4.0.0",
     "redux-form": "^7.0.3"


### PR DESCRIPTION
react-bootstrap isn't even in use in this repo any longer so we can prune it. 